### PR TITLE
avoid using using one-time indexes

### DIFF
--- a/lib/hike/common.js
+++ b/lib/hike/common.js
@@ -1,5 +1,8 @@
 'use strict';
 
+// stdlib
+var fs = require('fs');
+
 
 // provides shortcut to define data property
 module.exports.prop = function (obj, name, val) {
@@ -16,4 +19,38 @@ module.exports.stub = function (obj, methods, msg) {
       throw new Error('Can\'t call `' + func + '()`' + msg);
     };
   });
+};
+
+
+// wrapper for `fs.statSync`, returns `null` if file does not exist
+module.exports.stat = function (pathname) {
+  var result = null;
+  try {
+    result = fs.statSync(pathname);
+  } catch (err) {
+    if ('ENOENT' !== err.code) {
+      throw err;
+    }
+  }
+
+  return result;
+};
+
+
+// wrapper for `fs.readdirSync` that filters out `.` files and
+// `~` swap files. Returns an empty `Array` if the directory does
+// not exist.
+module.exports.entries = function (pathname) {
+  var result = [];
+  try {
+    result = fs.readdirSync(pathname || '').filter(function (f) {
+      return !/^\.|~$|^\#.*\#$/.test(f);
+    }).sort();
+  } catch (err) {
+    if ('ENOENT' !== err.code) {
+      throw err;
+    }
+  }
+
+  return result;
 };

--- a/lib/hike/index.js
+++ b/lib/hike/index.js
@@ -11,7 +11,6 @@
 
 
 // stdlib
-var fs = require('fs');
 var path = require('path');
 
 
@@ -20,6 +19,7 @@ var _ = require('lodash');
 
 
 // internal
+var common = require('./common');
 var prop = require('./common').prop;
 
 
@@ -257,16 +257,7 @@ Index.prototype.find = function (logical_paths, options, fn) {
  **/
 Index.prototype.entries = function (pathname) {
   if (!this.__entries__[pathname]) {
-    try {
-      this.__entries__[pathname] = [];
-      this.__entries__[pathname] = fs.readdirSync(pathname || '').filter(function (f) {
-        return !/^\.|~$|^\#.*\#$/.test(f);
-      }).sort();
-    } catch (err) {
-      if ('ENOENT' !== err.code) {
-        throw err;
-      }
-    }
+    this.__entries__[pathname] = common.entries(pathname);
   }
 
   return this.__entries__[pathname];
@@ -282,14 +273,7 @@ Index.prototype.entries = function (pathname) {
  **/
 Index.prototype.stat = function (pathname) {
   if (null !== this.__stats__[pathname]) {
-    try {
-      this.__stats__[pathname] = null;
-      this.__stats__[pathname] = fs.statSync(pathname);
-    } catch (err) {
-      if ('ENOENT' !== err.code) {
-        throw err;
-      }
-    }
+    this.__stats__[pathname] = common.stat(pathname);
   }
 
   return this.__stats__[pathname];

--- a/lib/hike/trail.js
+++ b/lib/hike/trail.js
@@ -17,16 +17,9 @@ var Index = require('./index');
 var Paths = require('./paths');
 var Extensions = require('./extensions');
 var Aliases = require('./aliases');
+var common = require('./common');
 var prop = require('./common').prop;
 
-
-// internal helper that makes function proxies to index methods
-function index_proxy(proto, func) {
-  proto[func] = function () {
-    var index = this.index;
-    return index[func].apply(index, arguments);
-  };
-}
 
 /**
  *  new Trail(root = '.')
@@ -171,20 +164,31 @@ Object.defineProperty(Trail.prototype, 'index', {
  *
  *      function (path) { return path; }
  **/
-index_proxy(Trail.prototype, 'find');
+Trail.prototype.find = function () {
+  var index = this.index;
+  return index.find.apply(index, arguments);
+};
 
 
 /**
  *  Trail#entries(pathname) -> Array
+ *  - pathname(String): Pathname to get files list for.
  *
- *  Wrapper over [[Index#entries]] using one-time instance of [[Trail#index]].
+ *  Version of `fs.readdirSync` that filters out `.` files and
+ *  `~` swap files. Returns an empty `Array` if the directory 
+ *  does not exist.
  **/
-index_proxy(Trail.prototype, 'entries');
+Trail.prototype.entries = function (pathname) {
+  return common.entries(pathname);
+};
 
 
 /**
  *  Trail#stat(pathname) -> Stats|Null
+ *  - pathname(String): Pathname to get stats for.
  *
- *  Wrapper over [[Index#stat]] using one-time instance of [[Trail#index]].
+ *  Retuns `null` if file does not exists.
  **/
-index_proxy(Trail.prototype, 'stat');
+Trail.prototype.stat = function (pathname) {
+  return common.stat(pathname);
+};


### PR DESCRIPTION
Currently `Trail.stat` and `Trail.entries` functions just create an empty index, do something and discard index. The cached information in the index itself is never used.

The cached information itself isn't a big deal. But creating an index is a very costly operation because of three `*.clone().freeze()` calls.

This would speed up `eachLogicalPath` call in mincer 4-6 times according to [my benchmarks](https://gist.github.com/rlidwka/892d08876d737e265a86).
