### PR TITLE
patches to fix issues with 2.x

### DIFF
--- a/lib/cached_trail.js
+++ b/lib/cached_trail.js
@@ -9,9 +9,6 @@
 'use strict';
 
 
-var find_all = require('./find_all');
-
-
 /**
  *  new CachedTrail(trail)
  **/
@@ -70,7 +67,7 @@ function CachedTrail(trail) {
  *  See [[Trail#find]] for usage.
  **/
 CachedTrail.prototype.find = function(paths, options, func) {
-  return this.find_all(paths, options, func)[0];
+  return this._trail_proto.find.call(this, paths, options, func);
 };
 
 /**
@@ -79,7 +76,7 @@ CachedTrail.prototype.find = function(paths, options, func) {
  *  See [[Trail#find_all]] for usage.
  **/
 CachedTrail.prototype.find_all = function(paths, options, func) {
-  return find_all(this, paths, options, func);
+  return this._trail_proto.find_all.call(this, paths, options, func);
 };
 
 /**

--- a/lib/find_all.js
+++ b/lib/find_all.js
@@ -110,47 +110,47 @@ function find_in_base_path(self, logical_path, base_path, fn) {
   }
 }
 
-// Finds logical path across all `paths`
-function find_in_paths(self, logical_path, fn) {
-  var dirname  = path.dirname(logical_path);
-  var basename = path.basename(logical_path);
-
-  self.paths.forEach(function(p) {
-    match(self, path.resolve(p, dirname), basename, fn);
-  });
-}
-
 module.exports = function find_all(self, logical_paths, options, fn) {
   var result = [];
-
-  if (!fn) {
-    if (typeof(options) === 'function') {
-      fn = options;
-      options = {};
-    }
-  }
-
-  if (!options) {
-    options = {};
-  }
 
   if (!Array.isArray(logical_paths)) {
     logical_paths = [logical_paths];
   }
 
   var base_path = options.basePath || self.root;
+  var have_result = false;
 
   var iterator = function(p) {
-    result.push(fn ? fn(p) : p);
+    var fn_result;
+
+    if (fn) {
+      fn_result = fn(p);
+      have_result = !!fn_result;
+      result.push(fn_result);
+    } else {
+      have_result = true;
+      result.push(p);
+    }
   };
 
   logical_paths.forEach(function(logical_path) {
+    var dirname, basename, i;
+
     logical_path = logical_path.replace(/^\//, '');
 
     if (is_relative(logical_path)) {
       find_in_base_path(self, logical_path, base_path, iterator);
     } else {
-      find_in_paths(self, logical_path, iterator);
+      dirname  = path.dirname(logical_path);
+      basename = path.basename(logical_path);
+
+      for (i = 0; i < self.paths.length; i++) {
+        match(self, path.resolve(self.paths[i], dirname), basename, iterator);
+
+        if (have_result && options._firstMatch) {
+          break;
+        }
+      }
     }
   });
 

--- a/lib/trail.js
+++ b/lib/trail.js
@@ -153,7 +153,22 @@ function Trail(root) {
  *      function (path) { return path; }
  **/
 Trail.prototype.find = function(paths, options, func) {
-  return this.find_all(paths, options, func)[0];
+  var optionsCopy = {};
+
+  if (!func && typeof(options) === 'function') {
+    func = options;
+    options = {};
+  }
+
+  if (options) {
+    Object.keys(options).forEach(function (k) {
+      optionsCopy[k] = options[k];
+    });
+  }
+
+  optionsCopy._firstMatch = true;
+
+  return this.find_all(paths, optionsCopy, func)[0];
 };
 
 /**
@@ -167,7 +182,18 @@ Trail.prototype.find = function(paths, options, func) {
  *  See [[Trail#find]] for details.
  **/
 Trail.prototype.find_all = function(logical_paths, options, func) {
-  var result = find_all(this, logical_paths, options, func);
+  var result;
+
+  if (!func && typeof(options) === 'function') {
+    func = options;
+    options = {};
+  }
+
+  if (!options) {
+    options = {};
+  }
+
+  result = find_all(this, logical_paths, options, func);
 
   // cache for regexps;
   // without it find_all() will create the same regexp


### PR DESCRIPTION
#10 is fixed by adding `_firstMatch` flag making `find_all` function stop looking for other paths after first match.
#11 is fixed just by reverting the potentially breaking change
